### PR TITLE
Fix links to pcl downloads

### DIFF
--- a/docs/modules/cli/pages/user-guide.adoc
+++ b/docs/modules/cli/pages/user-guide.adoc
@@ -66,8 +66,8 @@ Client is distributed over Payara's Nexus Repository under following coordinates
 
 ==== Download links
 
-* xref:{release-repo}/fish/payara/cloud/pcl/{release-version}/pcl-{release-version}.zip[Full Distribution (.zip)]
-* xref:{release-repo}/fish/payara/cloud/pcl/{release-version}/pcl-{release-version}.jar[Executable JAR only (.jar)]
+* link:{release-repo}/fish/payara/cloud/pcl/{release-version}/pcl-{release-version}.zip[Full Distribution (.zip)]
+* link:{release-repo}/fish/payara/cloud/pcl/{release-version}/pcl-{release-version}.jar[Executable JAR only (.jar)]
 
 // === Help
 // === Output options


### PR DESCRIPTION
xref with url apparently doesn't work in antorra like it does in plain asciidoctor